### PR TITLE
/staff/readme ページにスタッフ向けREADMEを表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'wdm', '~> 0.1.0', platforms: [:mswin, :mingw]
 
 gem 'bootstrap-sass', require: false
 gem 'builder'
+gem 'octokit', '~> 4.0'
 gem 'rack-rewrite'
 gem 'sass'
 gem 'slim'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.8)
     execjs (2.6.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     haml (4.0.7)
       tilt
@@ -106,11 +108,14 @@ GEM
     mini_portile (0.6.2)
     minitest (5.8.2)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (3.0.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    octokit (4.2.0)
+      sawyer (~> 0.6.0, >= 0.5.3)
     padrino-helpers (0.12.5)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.12.5)
@@ -140,6 +145,9 @@ GEM
       tins (<= 1.6.0)
     ruby-progressbar (1.7.5)
     sass (3.4.19)
+    sawyer (0.6.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
     scss_lint (0.42.2)
       rainbow (~> 2.0)
       sass (~> 3.4.15)
@@ -186,6 +194,7 @@ DEPENDENCIES
   middleman-blog
   middleman-deploy
   middleman-livereload
+  octokit (~> 4.0)
   rack-rewrite
   sass
   scss_lint

--- a/config.rb
+++ b/config.rb
@@ -65,6 +65,11 @@ helpers do
     data.humans.supporters.each { |s| arr << s }
     arr
   end
+
+  def staff_readme
+    readme = Octokit.readme 'johokaigi/johokaigi_staff', accept: 'application/vnd.github.html'
+    readme.force_encoding('UTF-8')
+  end
 end
 
 set :css_dir, 'assets/stylesheets'

--- a/source/assets/stylesheets/_humans_list.scss
+++ b/source/assets/stylesheets/_humans_list.scss
@@ -3,11 +3,23 @@
 
   &_title {
     display: inline-block;
-    margin: 0 0 30px;
+    margin: 30px 0 20px;
     border-bottom: 3px solid $brand-color;
     padding-bottom: 5px;
     font: {
       size: 1.8em;
+      weight: normal;
+    }
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  &_subTitle {
+    margin: 30px 0 20px;
+    font: {
+      size: 1.6em;
       weight: normal;
     }
 

--- a/source/assets/stylesheets/_mixins.scss
+++ b/source/assets/stylesheets/_mixins.scss
@@ -37,6 +37,7 @@
 }
 
 @mixin markdown {
+  h1,
   h2,
   h3,
   h4 {
@@ -46,6 +47,12 @@
       top: 1.5em;
       bottom: .8em;
     }
+  }
+
+  h1 {
+    font-size: 2em;
+    border-bottom: 3px solid  $brand-color;
+    padding-bottom: 5px;
   }
 
   h2 {

--- a/source/assets/stylesheets/_staff_readme.scss
+++ b/source/assets/stylesheets/_staff_readme.scss
@@ -1,0 +1,8 @@
+.staffReadme {
+  @include card;
+  @include markdown;
+
+  *:first-child {
+    margin-top: 0;
+  }
+}

--- a/source/assets/stylesheets/application.scss
+++ b/source/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@
 @import 'page_header';
 @import 'section';
 @import 'sponsors_text';
+@import 'staff_readme';
 @import 'tips_article';
 
 body {

--- a/source/staff/index.slim
+++ b/source/staff/index.slim
@@ -8,7 +8,8 @@ descriptipon: 情報会議のスタッフ一覧です。
     h1.pageHeader_title
       = current_page.data.title
   .humansList
-    h2.humansList_title オーガナイザー
+    h2.humansList_title スタッフ
+    h3.humansList_subTitle オーガナイザー
     ul.list-unstyled.list-inline
       - data.humans.organizers.each do |organizer|
         li.humansList_item
@@ -16,7 +17,7 @@ descriptipon: 情報会議のスタッフ一覧です。
           .humansList_name = organizer.name
           .humansList_url = link_to organizer.url, organizer.url, target: '_blank'
 
-    h2.humansList_title 協力
+    h3.humansList_subTitle 協力
     ul.list-unstyled.list-inline
       - data.humans.supporters.each do |supporter|
         li.humansList_item
@@ -26,6 +27,9 @@ descriptipon: 情報会議のスタッフ一覧です。
 
     h2.humansList_title お問い合わせ
     p = link_to 'フォームを開く', 'http://goo.gl/forms/8MsDcCYBLJ', target: '_blank'
+
+    h2.humansList_title スタッフの方へ
+    p = link_to 'README', '/staff/readme'
 
     hr
 

--- a/source/staff/readme.slim
+++ b/source/staff/readme.slim
@@ -1,0 +1,16 @@
+---
+title: README
+descriptipon: 情報会議を手伝ってくれる皆さんにやっていただきたいことをご説明します。
+---
+
+.container
+  .pageHeader
+    h1.pageHeader_title
+      = current_page.data.title
+
+  .staffReadme
+    p
+      | 原文は<a href="https://github.com/johokaigi/johokaigi_staff/blob/master/README.md" target="_blank">
+      | johokaigi/johokaigi_staff</a>に掲載しています。
+    hr
+    = staff_readme


### PR DESCRIPTION
https://github.com/johokaigi/johokaigi_staff/blob/master/README.md この内容をhttp://johokaigi.org/staff/readme に表示するようにしました。
現状は**README側を変更しただけでは反映されない**ので、johokaigi.org側を更新する場合はjohokaigi/johokaigiで空コミットするなりしてdeployを走らせる必要があります。

close #61 
